### PR TITLE
BugFix - Unexpected behavior when #booths over 16

### DIFF
--- a/src/utils/shuffledBingo.js
+++ b/src/utils/shuffledBingo.js
@@ -37,7 +37,7 @@ export default function shuffledBingo (patterns) {
 
     const shuffledBooth = Object.keys(boothSet).reduce((set, key) => {
       const validSeed = seed.filter(s => s < boothSet[key].length)
-      set[key] = boothSet[key].map((_, pos, arr) => arr[validSeed[pos]])
+      set[key] = boothSet[key].map((_, pos, arr) => arr[validSeed[pos % validSeed.length]])
       return set
     }, {})
 


### PR DESCRIPTION
When number of booths of some significant over 16,
shuffledBooth will include undefined object